### PR TITLE
docs: agregar nombres completos del equipo

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,5 +33,5 @@ uvicorn app.main:app --reload
 
 ## 👥 Integrantes del Equipo
 * Dev Principal:
-* Product Owner del módulo:
+* Product Owner del módulo: John Steven Lopez Velez
 * Scrum Master asignado:


### PR DESCRIPTION
Se agrego el nombre del Product Owner del módulo en la sección Integrantes del Equipo del README.md.
